### PR TITLE
Fix autodiscovery of calendars

### DIFF
--- a/calendar/config.inc.php.dist
+++ b/calendar/config.inc.php.dist
@@ -194,12 +194,12 @@ $config['calendar_ical_debug'] = false;
 // Pre-installed calendars, added at first access to calendar section
 // Caldav driver is supported only
  $config['calendar_preinstalled_calendars'] = array(
-    'Personal' => array(
+    'NextCloud' => array(
                     'driver'      => 'caldav',
 		    'name'        => 'Personal',
                     'caldav_user' => '%u',
                     'caldav_pass' => '%p',
-                    'caldav_url'  => 'https://www.domain.ltd/cloud/remote.php/dav/calendars/%u/personal',
+                    'caldav_url'  => 'https://www.domain.ltd/cloud/remote.php/dav/calendars/%u/',
                     'color'       => '#0000FF',
                     'showAlarms'  => 1));
 ?>


### PR DESCRIPTION
There were a few issues that prevented autodiscovery of Nextcloud calendars from working:
- the SabreDAV class to check for has changed
- the deduplication routine needs to account for escaping of the `@` character

Additionally, some responses have changed to be arrays of values instead of plain values.

Tested with NextCloud 11.0.0, Roundcube 1.2.3 and PHP 7.1.0.