### PR TITLE
Support for remote iCalendar subscriptions over CalDAV

### DIFF
--- a/calendar/calendar_ui.js
+++ b/calendar/calendar_ui.js
@@ -3525,7 +3525,7 @@ function rcube_calendar_ui(settings)
 
       // insert to #calendar-select options if writeable
       select = $('#edit-calendar');
-      if (fc && has_permission(cal, 'i') && select.length && !select.find('option[value="'+id+'"]').length) {
+      if (fc && has_permission(cal, 'i') && select.length && !select.find('option[value="'+id+'"]').length && cal.editable) {
         $('<option>').attr('value', id).html(cal.name).appendTo(select);
       }
     }

--- a/calendar/drivers/ical/ical_driver.php
+++ b/calendar/drivers/ical/ical_driver.php
@@ -133,7 +133,7 @@ class ical_driver extends calendar_driver
                 $arr['name'] = html::quote($arr['name']);
                 $arr['listname'] = html::quote($arr['name']);
                 $arr['rights'] = 'lrswikxteav';
-                $arr['editable'] = true;
+                $arr['editable'] = false;
                 $arr['ical_pass']   = $this->_decrypt_pass($arr['ical_pass']);
                 $this->calendars[$arr['calendar_id']] = $arr;
                 $calendar_ids[] = $this->rc->db->quote($arr['calendar_id']);

--- a/calendar/lib/calendar_ui.php
+++ b/calendar/lib/calendar_ui.php
@@ -367,7 +367,7 @@ class calendar_ui
     $select = new html_select($attrib);
 
     foreach ((array)$this->cal->get_calendars() as $id => $prop) {
-      if ($prop['editable'] || strpos($prop['rights'], 'i') !== false)
+      if ($prop['editable'] && strpos($prop['rights'], 'i') !== false)
         $select->add($prop['name'], $id);
     }
 


### PR DESCRIPTION
This pull request adds correct GUI support for read-only calendars (like the contact birthdays calendar) and forwards remote calendar subscriptions to the iCal plugin. Nextcloud itself does not provide events for subscribed calendars.

To use subscribed calendars, add `"ical"` to `$config['calendar_driver_default']`. Note that the subscribed calendars will only show up after refreshing the page because we can only inject them into the database and can't add them via the iCal plugin.