### PR TITLE
Fix RCMAIL_CHARSET usage

### DIFF
--- a/calendar/calendar.php
+++ b/calendar/calendar.php
@@ -3407,7 +3407,13 @@ if(count($cals) > 0){
     $uid     = rcube_utils::get_input_value('_uid', rcube_utils::INPUT_POST);
     $mbox    = rcube_utils::get_input_value('_mbox', rcube_utils::INPUT_POST);
     $mime_id = rcube_utils::get_input_value('_part', rcube_utils::INPUT_POST);
-    $charset = RCUBE_CHARSET;
+    if (defined(RCUBE_CHARSET)) {
+        $charset = RCUBE_CHARSET;
+    } elseif (defined(RCMAIL_CHARSET)) {
+        $charset = RCMAIL_CHARSET;
+    } else {
+        $charset = $this->rc->config->get('default_charset');
+    }
 
     // establish imap connection
     $imap = $this->rc->get_storage();

--- a/calendar/lib/calendar_ui.php
+++ b/calendar/lib/calendar_ui.php
@@ -295,8 +295,16 @@ class calendar_ui
     }
 
     $classes = array('calendar', 'cal-'  . asciiwords($id, true));
+    if (defined(RCUBE_CHARSET)) {
+        $charset = RCUBE_CHARSET;
+    } elseif (defined(RCMAIL_CHARSET)) {
+        $charset = RCMAIL_CHARSET;
+    } else {
+        $charset = $this->rc->config->get('default_charset');
+    }
+
     $title = $prop['title'] ?: ($prop['name'] != $prop['listname'] || strlen($prop['name']) > 25 ?
-      html_entity_decode($prop['name'], ENT_COMPAT, RCMAIL_CHARSET) : '');
+      html_entity_decode($prop['name'], ENT_COMPAT, $charset) : '');
 
     if ($prop['virtual'])
       $classes[] = 'virtual';

--- a/libcalendaring/lib/OldSabre/VObject/Property/libcalendaring.php
+++ b/libcalendaring/lib/OldSabre/VObject/Property/libcalendaring.php
@@ -1221,10 +1221,17 @@ class libcalendaring extends rcube_plugin
         $url = str_replace('&_preload=1', '', $_SERVER['REQUEST_URI']);
         $message = $this->rc->gettext('loadingdata');
 
-        header('Content-Type: text/html; charset=' . RCUBE_CHARSET);
+        if (defined(RCUBE_CHARSET)) {
+            $charset = RCUBE_CHARSET;
+        } elseif (defined(RCMAIL_CHARSET)) {
+            $charset = RCMAIL_CHARSET;
+        } else {
+            $charset = $this->rc->config->get('default_charset');
+        }
+        header('Content-Type: text/html; charset=' . $charset);
         print "<html>\n<head>\n"
             . '<meta http-equiv="refresh" content="0; url='.Q($url).'">' . "\n"
-            . '<meta http-equiv="content-type" content="text/html; charset='.RCUBE_CHARSET.'">' . "\n"
+            . '<meta http-equiv="content-type" content="text/html; charset=' . $charset . '">' . "\n"
             . "</head>\n<body>\n$message\n</body>\n</html>";
         exit;
     }
@@ -1318,7 +1325,14 @@ class libcalendaring extends rcube_plugin
 
             foreach ($this->ical_parts as $mime_id) {
                 $part    = $this->ical_message->mime_parts[$mime_id];
-                $charset = $part->ctype_parameters['charset'] ?: RCMAIL_CHARSET;
+                if (defined(RCUBE_CHARSET)) {
+                    $def_charset = RCUBE_CHARSET;
+                } elseif (defined(RCMAIL_CHARSET)) {
+                    $def_charset = RCMAIL_CHARSET;
+                } else {
+                    $def_charset = $this->rc->config->get('default_charset');
+                }
+                $charset = $part->ctype_parameters['charset'] ?: $def_charset;
                 $this->mail_ical_parser->import($this->ical_message->get_part_body($mime_id, true), $charset);
 
                 // check if the parsed object is an instance of a recurring event/task
@@ -1357,7 +1371,13 @@ class libcalendaring extends rcube_plugin
      */
     public function mail_get_itip_object($mbox, $uid, $mime_id, $type = null)
     {
-        $charset = RCMAIL_CHARSET;
+        if (defined(RCUBE_CHARSET)) {
+            $charset = RCUBE_CHARSET;
+        } elseif (defined(RCMAIL_CHARSET)) {
+            $charset = RCMAIL_CHARSET;
+        } else {
+            $charset = $this->rc->config->get('default_charset');
+        }
 
         // establish imap connection
         $imap = $this->rc->get_storage();

--- a/libcalendaring/lib/libcalendaring_itip.php
+++ b/libcalendaring/lib/libcalendaring_itip.php
@@ -262,11 +262,19 @@ class libcalendaring_itip
         }
 
         // compose multipart message using PEAR:Mail_Mime
+        if (defined(RCUBE_CHARSET)) {
+            $charset = RCUBE_CHARSET;
+        } elseif (defined(RCMAIL_CHARSET)) {
+            $charset = RCMAIL_CHARSET;
+        } else {
+            $charset = $this->rc->config->get('default_charset');
+        }
+
         $message = new Mail_mime("\r\n");
         $message->setParam('text_encoding', 'quoted-printable');
         $message->setParam('head_encoding', 'quoted-printable');
-        $message->setParam('head_charset', RCMAIL_CHARSET);
-        $message->setParam('text_charset', RCMAIL_CHARSET . ";\r\n format=flowed");
+        $message->setParam('head_charset', $charset);
+        $message->setParam('text_charset', $charset . ";\r\n format=flowed");
         $message->setContentType('multipart/alternative');
 
         // compose common headers array
@@ -286,7 +294,7 @@ class libcalendaring_itip
         $ical = libcalendaring::get_ical();
         $ics = $ical->export(array($event), $method, false, $method == 'REQUEST' && $this->plugin->driver ? array($this->plugin->driver, 'get_attachment_body') : false);
         $filename = $event['_type'] == 'task' ? 'todo.ics' : 'event.ics';
-        $message->addAttachment($ics, 'text/calendar', $filename, false, '8bit', '', RCMAIL_CHARSET . "; method=" . $method);
+        $message->addAttachment($ics, 'text/calendar', $filename, false, '8bit', '', $charset . "; method=" . $method);
 
         return $message;
     }


### PR DESCRIPTION
In RoundCube 1.3 there's no RCMAIL_CHARSET define, it uses RCUBE_CHARSET. I modified all occurencies of RCMAIL_CHARSET to work with all RC versions.